### PR TITLE
Make Arch Steam and multilib opt-in

### DIFF
--- a/usr/local/bin/bootystrap
+++ b/usr/local/bin/bootystrap
@@ -126,7 +126,6 @@ xorg=(
 steam_packages=(
   lib32-mesa         # steam
   lib32-systemd      # steam
-  lib32-vulkan-intel # steam
   steam              # steam
 )
 
@@ -137,13 +136,20 @@ postinstall(){
 }
 
 # booty config
+enable_steam=false
 enable_multilib=false
 bootycfg="/etc/bootystrap"
 prompt/cfg(){
   local id="$1"
   local default="$2"
+  local forced="${3:-}"
+  local answer
   [ -e "$id" ] || echo "$default" > "$id"
-  read -rp "$id? : " -i "$(cat "$id")" -e answer
+  if [ -n "$forced" ]; then
+    answer="$forced"
+  else
+    read -rp "$id? : " -i "$(cat "$id")" -e answer
+  fi
   echo "$answer" > "$id"
 
   case "$id:$answer" in
@@ -158,8 +164,11 @@ prompt/cfg(){
     wifi:1)
       util+=( iwd )
       ;;
-    steam:1)
+    multilib:1)
       enable_multilib=true
+      ;;
+    steam:1)
+      enable_steam=true
       xtra+=( "${steam_packages[@]}" )
       ;;
     host:hartford)
@@ -185,7 +194,7 @@ prompt/cfg(){
       postinstall(){
         local user="$1"
 
-        if $enable_multilib; then
+        if $enable_steam; then
           [ -e "/etc/sysctl.d/80-gamecompatibility.conf" ] || {
             echo "vm.max_map_count = 2147483642" > /etc/sysctl.d/80-gamecompatibility.conf
             sysctl --system
@@ -217,9 +226,18 @@ prompt/cfg "user" "nesta"
 prompt/cfg "timezone" "US/Mountain" # /usr/share/zoneinfo/...
 prompt/cfg "laptop" 0
 prompt/cfg "wifi" 0
-prompt/cfg "desktop_environment" "xmonad"
 prompt/cfg "host" "$(uname -n)"
+prompt/cfg "desktop_environment" "xmonad"
 prompt/cfg "steam" 0
+prompt/cfg "multilib" 0 "$($enable_steam && echo 1)"
+
+if $enable_multilib; then
+  case "$(cat "$bootycfg/host")" in
+    hartford)
+      xtra+=( lib32-vulkan-intel )
+      ;;
+  esac
+fi
 
 # configure pacman.conf
 grep -qF "Include = /etc/pacman.d/bootystrap" /etc/pacman.conf || cat << EOF >> /etc/pacman.conf

--- a/usr/local/bin/bootystrap
+++ b/usr/local/bin/bootystrap
@@ -7,6 +7,7 @@ die(){ log "$*"; exit 1; }
 pkg(){ pacman -S --noconfirm --needed "$@"; }
 
 (
+  # shellcheck disable=SC1091
   . /etc/os-release
   [ "$NAME" = "Arch Linux" ] || die "Is this Arch Linux?"
   [ $EUID -eq 0 ] || die "Please execute as superuser."
@@ -122,6 +123,13 @@ xorg=(
   xterm
 )
 
+steam_packages=(
+  lib32-mesa         # steam
+  lib32-systemd      # steam
+  lib32-vulkan-intel # steam
+  steam              # steam
+)
+
 xtra=()
 
 postinstall(){
@@ -150,8 +158,11 @@ prompt/cfg(){
     wifi:1)
       util+=( iwd )
       ;;
-    host:hartford)
+    steam:1)
       enable_multilib=true
+      xtra+=( "${steam_packages[@]}" )
+      ;;
+    host:hartford)
       gui+=(
         libva              # VA-API base
         intel-media-driver # VA-API NewGen/ARC Driver
@@ -165,10 +176,6 @@ prompt/cfg(){
         cups               # printing
         ghostscript        # printing / canon LBP6000
         input-leap         # kvm (synergy/barrier replacement - deskflow for wayland)
-        lib32-mesa         # steam
-        lib32-systemd      # steam
-        lib32-vulkan-intel # steam
-        steam              # steam
       )
 
       aur+=(
@@ -178,10 +185,12 @@ prompt/cfg(){
       postinstall(){
         local user="$1"
 
-        [ -e "/etc/sysctl.d/80-gamecompatibility.conf" ] || {
-          echo "vm.max_map_count = 2147483642" > /etc/sysctl.d/80-gamecompatibility.conf
-          sysctl --system
-        }
+        if $enable_multilib; then
+          [ -e "/etc/sysctl.d/80-gamecompatibility.conf" ] || {
+            echo "vm.max_map_count = 2147483642" > /etc/sysctl.d/80-gamecompatibility.conf
+            sysctl --system
+          }
+        fi
 
         # configure printing
         systemctl enable --now cups
@@ -210,6 +219,7 @@ prompt/cfg "laptop" 0
 prompt/cfg "wifi" 0
 prompt/cfg "desktop_environment" "xmonad"
 prompt/cfg "host" "$(uname -n)"
+prompt/cfg "steam" 0
 
 # configure pacman.conf
 grep -qF "Include = /etc/pacman.d/bootystrap" /etc/pacman.conf || cat << EOF >> /etc/pacman.conf

--- a/usr/local/bin/bootystrap
+++ b/usr/local/bin/bootystrap
@@ -138,6 +138,7 @@ postinstall(){
 # booty config
 enable_steam=false
 enable_multilib=false
+enable_wifi=false
 bootycfg="/etc/bootystrap"
 prompt/cfg(){
   local id="$1"
@@ -153,16 +154,9 @@ prompt/cfg(){
   echo "$answer" > "$id"
 
   case "$id:$answer" in
-    laptop:1)
-      util+=( "${laptop[@]}" )
-      echo 1 > wifi
-      ;;
     desktop_environment:xmonad)
       gui+=( "${xorg[@]}" "${fonts[@]}" xmonad xmonad-contrib )
       aur+=( xsct )
-      ;;
-    wifi:1)
-      util+=( iwd )
       ;;
     multilib:1)
       enable_multilib=true
@@ -217,15 +211,18 @@ prompt/cfg(){
       }
       ;;
     host:zb14x)
+      enable_wifi=true
+      util+=( "${laptop[@]}" )
       core+=( sof-firmware )
       ;;
+    host:*)
+      rm -f "$bootycfg/host"
+      die "unrecognized host '$answer'; host config reset, rerun bootystrap and choose a known host"
   esac
 }
 mkdir -p "$bootycfg" && cd "$_"
 prompt/cfg "user" "nesta"
 prompt/cfg "timezone" "US/Mountain" # /usr/share/zoneinfo/...
-prompt/cfg "laptop" 0
-prompt/cfg "wifi" 0
 prompt/cfg "host" "$(uname -n)"
 prompt/cfg "desktop_environment" "xmonad"
 prompt/cfg "steam" 0
@@ -238,6 +235,8 @@ if $enable_multilib; then
       ;;
   esac
 fi
+
+$enable_wifi && util+=( iwd )
 
 # configure pacman.conf
 grep -qF "Include = /etc/pacman.d/bootystrap" /etc/pacman.conf || cat << EOF >> /etc/pacman.conf
@@ -298,7 +297,7 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 # system configuration
 ln -sf "/usr/share/zoneinfo/$(cat $bootycfg/timezone)" /etc/localtime
 ln -sf /usr/bin/vim /usr/bin/vi
-[ "$(cat $bootycfg/wifi)" = "1" ] && systemctl enable --now iwd.service
+$enable_wifi && systemctl enable --now iwd.service
 systemctl enable --now systemd-timesyncd.service
 systemctl enable --now keyd.service
 #systemctl enable --now docker.service eats battery, look into toggling via tlp + protecting against running containers


### PR DESCRIPTION
Improvements to root bootystrap:
- refactor steam to be opt-in
  - force-set multilib if steam is selected (added 'force-set' arg to config prompts)
- derive host-specific laptop, wifi, and 32-bit Intel graphics behavior from host profiles
